### PR TITLE
Initialize Codex self-management files

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -1,0 +1,9 @@
+# Brain
+
+Dies ist das Arbeitsgedächtnis für das Projekt **Ideenberater**.
+Hier werden Fragen, Beobachtungen und wichtige Notizen festgehalten.
+
+## 2025-07-27
+- Initiale Projektstruktur angelegt.
+- Konzept, Dokumentation und Milestones erstellt.
+- Nächster Schritt: Arbeits-Prompt definieren und erste Code-Dateien planen.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [2025-07-27]
+- Initiale Dateien in `codex/daten/` angelegt:
+  - `konzept.md`
+  - `docs.md`
+  - `milestones.md`
+  - `brain.md`
+  - `changelog.md`
+  - `prompt.md` (wird im Anschluss generiert)

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -1,0 +1,57 @@
+# Dokumentation
+
+Dieses Dokument beschreibt die wichtigsten Technologien, Module und Abläufe
+im Projekt **Ideenberater**.
+
+## Technologieübersicht
+
+| Bereich        | Technologie                     |
+|----------------|---------------------------------|
+| Webserver      | Apache (Docker)                 |
+| Sprache        | PHP (ohne Framework)            |
+| KI-API         | OpenRouter                      |
+| Container      | Docker, docker-compose          |
+| Reverse Proxy  | Nginx                           |
+| SSL            | Certbot (Let's Encrypt)         |
+
+## Verzeichnisstruktur (geplant)
+
+```
+/opt/ideenberater
+├── docker-compose.yml
+├── php/
+│   ├── index.php
+│   ├── request.php
+│   └── config.php (.env)
+└── nginx/
+    └── ideenberater.conf
+```
+
+## PHP-Ablauf
+1. Nutzer ruft `index.php` auf und gibt sein Problem ein.
+2. Das Formular sendet die Eingabe via POST an `request.php`.
+3. `request.php` liest den OpenRouter-Token aus `config.php` und stellt eine
+   HTTP-Anfrage an die OpenRouter-API.
+4. Die Antwort wird im Browser ausgegeben (HTML). Optional könnte hier auch
+   eine Markdown- oder PDF-Exportfunktion eingebunden werden.
+
+## OpenRouter-API
+- Endpoint: wird über die Konfiguration festgelegt.
+- Authentifizierung: Bearer-Token aus `.env` bzw. `config.php`.
+- Rückgabe: JSON mit den KI-Vorschlägen, die in `request.php` gerendert werden.
+
+## Installationsskript (`install.sh`)
+Das Skript führt folgende Schritte aus:
+1. Pakete prüfen und ggf. installieren.
+2. Parameter (Domain, Token, Mail) abfragen.
+3. Repository nach `/opt/ideenberater` klonen.
+4. Docker-Container per `docker-compose up -d` starten.
+5. Nginx-Site anlegen und aktivieren.
+6. SSL-Zertifikat via Certbot erstellen.
+7. Cronjob für Auto-Renewal einrichten.
+
+## Erweiterungsmöglichkeiten
+- Logging der Nutzeranfragen in einer Datei oder Datenbank.
+- Export der KI-Antwort als Markdown oder PDF.
+- Sprachumschaltung (DE/EN) über GET-Parameter oder Session.
+- Einfache Authentifizierung per htpasswd oder ähnlichem Mechanismus.

--- a/codex/daten/konzept.md
+++ b/codex/daten/konzept.md
@@ -1,0 +1,43 @@
+# Konzept: Ideenberater
+
+Das Projekt "Ideenberater" ist eine leichtgewichtige PHP-Webanwendung, die
+mithilfe der OpenRouter-API kreative Vorschläge für Softwareideen generiert.
+Die Anwendung läuft in einem Docker-Container (Apache + PHP) und wird per
+Nginx als Reverse Proxy unter einer beliebigen Domain bereitgestellt. Die
+Installation erfolgt automatisiert über ein Skript `install.sh`, das den
+kompletten Server einrichtet, inklusive SSL via Let's Encrypt.
+
+## Ziel
+* Schnelle Bereitstellung einer webbasierten Ideenberatung.
+* Minimale Abhängigkeiten: nur Docker, Nginx, PHP.
+* Vollautomatische Installation inkl. Zertifikatsverwaltung.
+
+## Hauptkomponenten
+1. **PHP-Webapp**
+   - `index.php`: Formular für Nutzereingaben
+   - `request.php`: Weiterleitung der Anfrage an die OpenRouter-API und
+     Rückgabe der Antwort
+   - `.env`/`config.php`: Speicherung des API-Tokens
+
+2. **Docker-Umgebung**
+   - Container mit Apache und PHP
+   - Bereitstellung des Webverzeichnisses
+
+3. **Installationsskript** (`install.sh`)
+   - Prüft und installiert erforderliche Pakete (Docker, docker-compose,
+     nginx, certbot)
+   - Fragt Domain, OpenRouter-Token und E-Mail für SSL ab
+   - Klont das Repository (z. B. nach `/opt/ideenberater`)
+   - Startet den Docker-Container
+   - Richtet Nginx als Reverse Proxy ein
+   - Erstellt und erneuert SSL-Zertifikate
+
+4. **Nginx-Konfiguration**
+   - Weiterleitung der externen Domain auf den internen Docker-Port
+   - TLS-Verschlüsselung via Let's Encrypt
+
+## Besonderheiten
+* Kein Einsatz von Node.js oder komplexen Frameworks.
+* Updates sind über `git pull` und Neustart des Containers möglich.
+* Optionale Erweiterungen: Logging, Exportfunktionen, Spracheinstellungen,
+  einfache Authentifizierung.

--- a/codex/daten/milestones.md
+++ b/codex/daten/milestones.md
@@ -1,0 +1,41 @@
+# Milestones für Ideenberater
+
+Dieser Zeitplan beschreibt die wichtigsten Schritte zur Umsetzung des Projekts
+bis zur einsatzbereiten Anwendung.
+
+## 1. Projektinitialisierung
+- Repository-Struktur anlegen (codex/daten)
+- Konzept- und Dokumentationsdateien erstellen
+
+## 2. Grundlegende Infrastruktur
+- `docker-compose.yml` erstellen
+- Basis-Dockerfile für PHP/Apache vorbereiten
+- Beispiel-Nginx-Config anlegen
+
+## 3. PHP-Webanwendung
+- `index.php` mit Eingabeformular
+- `request.php` für API-Aufrufe
+- `config.php` / `.env` mit Token-Verwaltung
+- Einfache Gestaltung (HTML/CSS)
+
+## 4. Installationsskript (`install.sh`)
+- Prüfung und Installation von Abhängigkeiten
+- Benutzerabfragen (Domain, Token, E-Mail)
+- Klonen des Repos und Start des Containers
+- Einrichtung von Nginx und SSL
+
+## 5. Tests & Optimierung
+- Funktionstests der API-Anbindung
+- Validierung der Nginx- und SSL-Konfiguration
+- Bereitstellung auf Testserver
+
+## 6. Erweiterungen (optional)
+- Logging und Exportfunktionen
+- Sprachumschaltung
+- Einfache Authentifizierung
+
+## 7. Dokumentation finalisieren
+- Ausführliche Nutzerdoku
+- Hinweise für Updates und Wartung
+
+Der aktuelle Fokus liegt auf **Milestone 1**.

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,0 +1,15 @@
+Du bist Codex, KI-Coding-Instanz für das Projekt "Ideenberater (PHP-Version, einfach & dockerisiert)".
+
+🔍 Ziel:
+Setze das Konzept aus codex/daten/konzept.md in funktionierenden Code um. Nutze die Informationen aus docs.md.
+Halte jede Veränderung in changelog.md fest, schreibe deinen Gedankengang in brain.md.
+
+Aktueller Stand:
+- Arbeitsverzeichnis: codex/daten/
+- Aktueller Milestone: Projektinitialisierung (Milestone 1 aus milestones.md)
+- Letzte Änderung: Initiale Dateien erstellt (siehe changelog.md)
+
+Diese Datei ersetzt ab sofort alle externen Prompts.
+Sie dient als zentrale Eingabebasis für deinen nächsten Lauf. Du wirst ab sofort immer mit folgendem Befehl ausgeführt:
+
+Codex, führe den Prompt in codex/daten/prompt.md aus.


### PR DESCRIPTION
## Summary
- establish `codex/daten/` directory for Codex
- describe project concept, docs, milestones and notes
- add change log and initial self-prompt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68865daf3d44832ea68ffd618e380d1a