### PR TITLE
Add setup script for development

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -7,3 +7,4 @@ Hier werden Fragen, Beobachtungen und wichtige Notizen festgehalten.
 - Initiale Projektstruktur angelegt.
 - Konzept, Dokumentation und Milestones erstellt.
 - Nächster Schritt: Arbeits-Prompt definieren und erste Code-Dateien planen.
+- Setup-Skript `env_setup.sh` erstellt, um Entwicklungsumgebung mit Docker, Nginx und PHP auszustatten.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -8,3 +8,6 @@
   - `brain.md`
   - `changelog.md`
   - `prompt.md` (wird im Anschluss generiert)
+
+## [2025-07-27] Added env_setup script
+- `env_setup.sh` in `codex/` legt Entwicklungswerkzeuge und Abhängigkeiten an.

--- a/codex/env_setup.sh
+++ b/codex/env_setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Setup environment for the Ideenberater project
+# Installs required packages and useful debugging tools
+
+set -e
+
+# Update package lists
+sudo apt-get update
+
+# Base utilities
+sudo apt-get install -y git curl build-essential vim nano less lsof net-tools
+
+# Docker and docker-compose
+sudo apt-get install -y docker.io docker-compose
+
+# Nginx and Certbot for reverse proxy and SSL
+sudo apt-get install -y nginx certbot python3-certbot-nginx
+
+# PHP runtime
+sudo apt-get install -y php php-cli php-fpm php-curl
+
+# Enable Docker service
+sudo systemctl enable --now docker
+
+# Print versions for verification
+docker --version
+docker-compose --version
+nginx -v
+php -v


### PR DESCRIPTION
## Summary
- add `env_setup.sh` for installing dependencies such as Docker, Nginx and PHP
- record change in `brain.md` and `changelog.md`

## Testing
- `shellcheck codex/env_setup.sh`
- `bash -n codex/env_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_688660312a30832eb82ef437eff95775