### PR TITLE
Add certbot renewal cronjob

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -19,3 +19,7 @@ Hier werden Fragen, Beobachtungen und wichtige Notizen festgehalten.
 - Installationsskript verbessert (Root-Prüfung, noninteractive apt).
 - Git-URL angepasst.
 - Indexseite mit einfachem CSS versehen.
+
+## 2025-07-27 (Codex Lauf Fortsetzung)
+- Cronjob für Zertifikatsrenewal in install.sh ergänzt.
+- shellcheck Hinweise umgesetzt (read -r, Variablen in Anführungszeichen).

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -22,3 +22,7 @@
 ## [2025-07-27] Verbesserungen
 - Installationsskript erweitert: Root-Prüfung, noninteractive apt, Repository-URL angepasst
 - Indexseite mit minimalem CSS versehen
+
+## [2025-07-27] Weitere Verbesserungen
+- Cronjob in install.sh für automatisches Zertifikats-Renewal eingerichtet.
+  - shellcheck Hinweise umgesetzt (read -r, Quotes)

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,9 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-read -p "Domain (z.B. ideenberater.domain.org): " DOMAIN
-read -p "OpenRouter Token: " TOKEN
-read -p "E-Mail für Let's Encrypt: " EMAIL
+read -r -p "Domain (z.B. ideenberater.domain.org): " DOMAIN
+read -r -p "OpenRouter Token: " TOKEN
+read -r -p "E-Mail für Let's Encrypt: " EMAIL
 
 # Pakete installieren
 export DEBIAN_FRONTEND=noninteractive
@@ -36,4 +36,7 @@ ln -s /etc/nginx/sites-available/ideenberater.conf /etc/nginx/sites-enabled/
 nginx -s reload
 
 # SSL Zertifikat
-certbot --nginx -d $DOMAIN --non-interactive --agree-tos -m $EMAIL
+certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos -m "$EMAIL"
+
+# Cronjob für Auto-Renewal des Zertifikats einrichten
+(crontab -l 2>/dev/null; echo "0 3 * * * certbot renew --quiet && systemctl reload nginx") | crontab -


### PR DESCRIPTION
## Summary
- automate SSL certificate renewal in `install.sh`
- document the change in `brain.md` and `changelog.md`

## Testing
- `shellcheck install.sh`

------
https://chatgpt.com/codex/tasks/task_e_688668a56e68832e8465b4eca2a8221c