### PR TITLE
Fehlerbehandlung in request.php

### DIFF
--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -29,3 +29,7 @@ Hier werden Fragen, Beobachtungen und wichtige Notizen festgehalten.
 - `shellcheck` ausgeführt, keine Warnungen.
 - `env_setup.sh` getestet; meldet systemd Fehler im Container, aber Pakete werden installiert.
 - `request.php` prüft nun Token und HTTP-Status und gibt Fehlermeldungen aus.
+
+## 2025-07-27 (Codex Lauf Weiter)
+- Fehlerbehandlung in `request.php` verbessert: prüft jetzt JSON-Decodierung und meldet Fehler.
+- Versuch, Container zu starten scheitert, da Docker-Daemon hier nicht läuft.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -31,3 +31,6 @@
 - `.gitignore` hinzugefügt
 - `shellcheck` und `env_setup.sh` getestet
 - `request.php` prüft Token und API-Status
+
+## [2025-07-27] Fehlerbehandlung verbessert
+- `request.php` prüft jetzt JSON-Fehler und bricht bei ungültiger Antwort ab.

--- a/php/request.php
+++ b/php/request.php
@@ -45,6 +45,10 @@ if ($httpCode !== 200) {
 curl_close($ch);
 
 $answer = json_decode($response, true);
+$jsonError = json_last_error();
+if ($jsonError !== JSON_ERROR_NONE) {
+    die('Ungültige Antwort von der API: ' . json_last_error_msg());
+}
 $suggestion = $answer['choices'][0]['message']['content'] ?? 'Keine Antwort erhalten.';
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- improve JSON error handling in `request.php`
- note reasoning in `brain.md`
- record changes in `changelog.md`

## Testing
- `shellcheck install.sh`
- `php -l php/request.php`
- `php -l php/index.php`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68866cad25b4832ea0b3adcff984f0d1