### PR TITLE
Add Markdown export feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # PHP dependencies
 vendor/
 
+# Exported markdown files
+php/exports/
+!php/exports/.gitkeep
+
 # IDE files
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Für lokale Tests kann `codex/env_setup.sh` ausgeführt werden. Danach startet d
 - Nimmt POST-Daten entgegen
 - Sendet Anfrage an OpenRouter-API (mit Token)
 - Gibt KI-Antwort im HTML zurück
+- Speichert die Antwort optional als Markdown-Datei in `php/exports/`
 
 ### .env.example / .env oder config.php
 - Das Beispiel `.env.example` zeigt die benötigten Variablen
@@ -91,9 +92,10 @@ Für lokale Tests kann `codex/env_setup.sh` ausgeführt werden. Danach startet d
 
 ---
 
+
 ## 🔧 Erweiterbar
 
-- Markdown- oder PDF-Export der KI-Antwort
+- PDF-Export der KI-Antwort
 - Sprachumschaltung (DE/EN)
 - Simple Authentifizierung (z. B. per Passwort)
 

--- a/codex/daten/brain.md
+++ b/codex/daten/brain.md
@@ -48,3 +48,8 @@ Hier werden Fragen, Beobachtungen und wichtige Notizen festgehalten.
 - Erweiterung der Konfiguration um `OPENROUTER_MODEL`.
 - PHP-Skripte angepasst, sodass das Modell über die Umgebung gesteuert werden kann.
 - Dokumentation und README entsprechend ergänzt.
+
+## 2025-07-27 (Codex Lauf erneut)
+- Markdown-Export umgesetzt.
+- Neue Ablage `php/exports/` erzeugt und in `.gitignore` eingetragen.
+- README, docs und Konzept aktualisiert.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -48,3 +48,8 @@
 - `OPENROUTER_MODEL` in `.env.example` aufgenommen
 - `config.php` und `request.php` verwenden nun diese Variable
 - README und docs ergänzt
+
+## [2025-07-27] Markdown-Export
+- `request.php` legt nun eine Markdown-Datei im Ordner `php/exports/` ab
+- `.gitignore` um `php/exports/` erweitert
+- Dokumentation und README aktualisiert

--- a/codex/daten/docs.md
+++ b/codex/daten/docs.md
@@ -36,7 +36,7 @@ im Projekt **Ideenberater**.
    HTTP-Anfrage an die OpenRouter-API.
 4. Die Antwort wird im Browser ausgegeben (HTML).
 5. Anfrage und Antwort werden in `logs/requests.log` protokolliert.
-   Optional könnte hier eine Markdown- oder PDF-Exportfunktion eingebunden werden.
+6. Die Antwort wird zusätzlich als Markdown-Datei im Verzeichnis `php/exports/` gespeichert.
 
 ## OpenRouter-API
 - Endpoint: wird über die Konfiguration festgelegt.
@@ -56,7 +56,7 @@ Das Skript führt folgende Schritte aus:
 
 ## Erweiterungsmöglichkeiten
 - Logging der Nutzeranfragen in einer Datei oder Datenbank.
-- Export der KI-Antwort als Markdown oder PDF.
+- PDF-Export der KI-Antwort.
 - Sprachumschaltung (DE/EN) über GET-Parameter oder Session.
 - Einfache Authentifizierung per htpasswd oder ähnlichem Mechanismus.
 

--- a/codex/daten/konzept.md
+++ b/codex/daten/konzept.md
@@ -40,5 +40,5 @@ kompletten Server einrichtet, inklusive SSL via Let's Encrypt.
 ## Besonderheiten
 * Kein Einsatz von Node.js oder komplexen Frameworks.
 * Updates sind über `git pull` und Neustart des Containers möglich.
-* Optionale Erweiterungen: Logging, Exportfunktionen, Spracheinstellungen,
+* Optionale Erweiterungen: Logging (bereits umgesetzt), Markdown-Exportfunktionen (umgesetzt), Spracheinstellungen,
   einfache Authentifizierung.

--- a/php/request.php
+++ b/php/request.php
@@ -61,6 +61,14 @@ $logFile = $logDir . '/requests.log';
 $logEntry = date('c') . ' | INPUT: ' . str_replace(["\n", "\r"], ' ', $problem)
     . ' | OUTPUT: ' . str_replace(["\n", "\r"], ' ', $suggestion) . PHP_EOL;
 file_put_contents($logFile, $logEntry, FILE_APPEND | LOCK_EX);
+
+// Antwort als Markdown exportieren
+$exportDir = __DIR__ . '/exports';
+if (!is_dir($exportDir)) {
+    mkdir($exportDir, 0775, true);
+}
+$exportFile = $exportDir . '/idea_' . date('Ymd_His') . '.md';
+file_put_contents($exportFile, "# Idee\n\n" . $suggestion);
 ?>
 <!DOCTYPE html>
 <html lang="de">
@@ -71,6 +79,7 @@ file_put_contents($logFile, $logEntry, FILE_APPEND | LOCK_EX);
 <body>
     <h1>Antwort</h1>
     <p><?php echo nl2br(htmlspecialchars($suggestion)); ?></p>
+    <p><a href="exports/<?php echo basename($exportFile); ?>" download>Markdown herunterladen</a></p>
     <a href="index.php">Neue Anfrage</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow saving answers as Markdown in `php/exports`
- link to export file in `request.php`
- ignore export directory via `.gitignore`
- document export in README, docs and concept
- log change in changelog and brain

## Testing
- `shellcheck install.sh codex/env_setup.sh`
- `php -l php/index.php php/request.php php/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68867e2445e0832e8382e1c69ba2b145